### PR TITLE
Allow connect argument to be undefined

### DIFF
--- a/websocket/src/client/mod.rs
+++ b/websocket/src/client/mod.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod message;
 pub mod options;
 pub mod result;
+mod ts_types;
 
 pub use config::WebSocketConfig;
 pub use error::Error;

--- a/websocket/src/client/options.rs
+++ b/websocket/src/client/options.rs
@@ -1,9 +1,9 @@
-use super::error::Error;
+use super::{error::Error, ts_types::IConnectOptionsOrUndefined};
 use super::result::Result;
 use super::Handshake;
 use js_sys::Object;
 use std::sync::Arc;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 use workflow_core::time::Duration;
 use workflow_wasm::extensions::object::*;
 
@@ -119,9 +119,9 @@ impl ConnectOptions {
     }
 }
 
-impl TryFrom<JsValue> for ConnectOptions {
+impl TryFrom<IConnectOptionsOrUndefined> for ConnectOptions {
     type Error = Error;
-    fn try_from(args: JsValue) -> Result<Self> {
+    fn try_from(args: IConnectOptionsOrUndefined) -> Result<Self> {
         let options = if let Some(args) = args.dyn_ref::<Object>() {
             let url = args.get_value("url")?.as_string();
             let block_async_connect = args.get_value("block")?.as_bool().unwrap_or(true);

--- a/websocket/src/client/ts_types.rs
+++ b/websocket/src/client/ts_types.rs
@@ -1,0 +1,43 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+#[wasm_bindgen(typescript_custom_section)]
+const IConnectOptions: &'static str = r#"
+
+/**
+ * Each Duration is composed of a whole number of seconds and a 
+ * fractional part represented in nanoseconds. 
+ * If the underlying system does not support nanosecond-level precision, 
+ * APIs binding a system timeout will typically round up the number of 
+ * nanoseconds.
+ */
+export interface Duration {
+    secs:number
+    nanos:number
+}
+
+/**
+ * Retry: Continuously attempt to connect to the server. This behavior will
+ * block `connect()` function until the connection is established.
+ * Fallback: Causes `connect()` to return immediately if the first-time connection
+ * has failed.
+ */
+export enum ConnectStrategy {
+    Retry,
+    Fallback
+}
+
+/**
+ * `ConnectOptions` is used to configure the `WebSocket` connectivity behavior.
+ */
+export interface IConnectOptions {
+    strategy: ConnectStrategy
+    url: string
+    connect_timeout: Duration
+    retry_interval: Duration
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IConnectOptions | undefined")]
+    pub type IConnectOptionsOrUndefined;
+}


### PR DESCRIPTION
This PR adds/changes the following:

- Replaces the original `JsValue` types in try_from() call in the trait implementation for type `ConnectOptions` with type `IConnectOptionsOrUndefined`, which allows a developer to omit the ConnectOptions arguments.