### PR TITLE
Fixes for Android and IOs platforms and websockets in cross-origin isolated environments

### DIFF
--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -328,18 +328,22 @@ impl Platform {
 static mut PLATFORM: Option<Platform> = None;
 
 pub fn platform() -> Platform {
-    if let Some(platform) = unsafe { PLATFORM.as_ref() } {
-        platform.clone()
+    if let Some(_platform) = unsafe { PLATFORM.as_ref() } {
+        _platform.clone()
     } else {
         cfg_if! {
             if #[cfg(target_os = "windows")] {
-                let platform = Platform::Windows;
+                let _platform = Platform::Windows;
             } else if #[cfg(target_os = "macos")] {
-                let platform = Platform::MacOS;
+                let _platform = Platform::MacOS;
             } else if #[cfg(target_os = "linux")] {
-                let platform = Platform::Linux;
+                let _platform = Platform::Linux;
+            } else if #[cfg(target_os = "android")] {
+                let _platform = Platform::Android;
+            } else if #[cfg(target_os = "ios")] {
+                let _platform = Platform::IOS;
             } else if #[cfg(target_arch = "wasm32")] {
-                let platform = if is_node() {
+                let _platform = if is_node() {
                     Platform::from_node()
                 } else {
                     Platform::from_web()
@@ -347,8 +351,8 @@ pub fn platform() -> Platform {
             }
         }
 
-        unsafe { PLATFORM.replace(platform.clone()) };
-        platform
+        unsafe { PLATFORM.replace(_platform.clone()) };
+        _platform
     }
 }
 

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -120,8 +120,8 @@ cfg_if! {
             detect().web
         }
 
-        //// Helper to test whether the application is running
-        //// in a cross-origin isolated browser environment (Flutter).
+        /// Helper to test whether the application is running
+        /// in a cross-origin isolated browser environment (Flutter).
         #[inline(always)]
         pub fn is_cross_origin_isolated()->bool{
             static CROSS_ORIGIN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -174,8 +174,8 @@ cfg_if! {
             false
         }
 
-        //// Helper to test whether the application is running
-        //// in a cross-origin isolated browser environment (Flutter).
+        /// Helper to test whether the application is running
+        /// in a cross-origin isolated browser environment (Flutter).
         #[inline(always)]
         pub fn is_cross_origin_isolated()->bool{
             false

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -120,6 +120,17 @@ cfg_if! {
             detect().web
         }
 
+        //// Helper to test whether the application is running
+        //// in a cross-origin isolated browser environment (Flutter).
+        #[inline(always)]
+        pub fn is_cross_origin_isolated()->bool{
+            static CROSS_ORIGIN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *CROSS_ORIGIN.get_or_init(|| {
+                js_sys::Reflect::get(&js_sys::global(), &"crossOriginIsolated".into())
+                .map(|v| !v.is_falsy())
+                .unwrap_or(false)
+            })
+        }
     }else{
 
         /// Helper to test whether the application is running under
@@ -160,6 +171,13 @@ cfg_if! {
         /// Helper to test whether the application is running under
         /// in a regular browser environment.
         pub fn is_web()->bool {
+            false
+        }
+
+        //// Helper to test whether the application is running
+        //// in a cross-origin isolated browser environment (Flutter).
+        #[inline(always)]
+        pub fn is_cross_origin_isolated()->bool{
             false
         }
     }

--- a/core/src/wasm/overrides.rs
+++ b/core/src/wasm/overrides.rs
@@ -8,7 +8,7 @@ use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
 use web_sys::{window, Blob, BlobPropertyBag, Url, Worker};
 
-use crate::runtime::is_web;
+use crate::runtime::{is_cross_origin_isolated, is_web};
 
 pub struct TimerManager {
     worker: Worker,         // Used to run the JavaScript code in a separate thread
@@ -240,7 +240,7 @@ pub fn init_timer_overrides() -> Result<(), String> {
     }
 
     // Persistent timers shall only be injected in a web context.
-    if !is_web() {
+    if !is_web() || is_cross_origin_isolated() {
         return Ok(());
     }
 

--- a/websocket/src/client/mod.rs
+++ b/websocket/src/client/mod.rs
@@ -1,12 +1,13 @@
 //!
 //! async WebSocket client functionality (requires a browser (WASM) or tokio (native) executors)
 //!
-
+//! 
 use cfg_if::cfg_if;
+mod wasm;
+pub use wasm::WebSocketInterface as _WSI;
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-        mod wasm;
         use wasm::WebSocketInterface;
     } else {
         mod native;

--- a/websocket/src/client/mod.rs
+++ b/websocket/src/client/mod.rs
@@ -1,7 +1,7 @@
 //!
 //! async WebSocket client functionality (requires a browser (WASM) or tokio (native) executors)
 //!
-//! 
+
 use cfg_if::cfg_if;
 mod wasm;
 pub use wasm::WebSocketInterface as _WSI;

--- a/websocket/src/client/wasm.rs
+++ b/websocket/src/client/wasm.rs
@@ -573,7 +573,23 @@ trait TrySendMessage {
 impl TrySendMessage for WebSocket {
     fn try_send(&self, message: &Message) -> Result<()> {
         match message {
-            Message::Binary(data) => self.send_with_u8_array(data).map_err(|e| e.into()),
+            Message::Binary(data) => {
+
+                if is_cross_origin_isolated() {
+                    // Create a non-shared ArrayBuffer for cross-origin isolated environments (Flutter).
+                    let array_buffer: ArrayBuffer = ArrayBuffer::new(data.len() as u32);
+                    let uint8_array = Uint8Array::new(&array_buffer);
+    
+                    let mut index = 0;
+                    for item in data{
+                        uint8_array.set_index(index, *item);
+                        index += 1;
+                    }
+                    self.send_with_array_buffer(&array_buffer).map_err(|e| e.into())
+                } else {
+                    self.send_with_u8_array(data).map_err(|e| e.into())
+                }
+            },
             Message::Text(text) => self.send_with_str(text).map_err(|e| e.into()),
             _ => {
                 panic!("WebSocket trying to convert unsupported message type: `{message:?}`");

--- a/websocket/src/client/wasm.rs
+++ b/websocket/src/client/wasm.rs
@@ -579,12 +579,7 @@ impl TrySendMessage for WebSocket {
                     // Create a non-shared ArrayBuffer for cross-origin isolated environments (Flutter).
                     let array_buffer: ArrayBuffer = ArrayBuffer::new(data.len() as u32);
                     let uint8_array = Uint8Array::new(&array_buffer);
-    
-                    let mut index = 0;
-                    for item in data{
-                        uint8_array.set_index(index, *item);
-                        index += 1;
-                    }
+                    uint8_array.copy_from(&data[..]);
                     self.send_with_array_buffer(&array_buffer).map_err(|e| e.into())
                 } else {
                     self.send_with_u8_array(data).map_err(|e| e.into())

--- a/websocket/src/client/wasm.rs
+++ b/websocket/src/client/wasm.rs
@@ -574,17 +574,17 @@ impl TrySendMessage for WebSocket {
     fn try_send(&self, message: &Message) -> Result<()> {
         match message {
             Message::Binary(data) => {
-
                 if is_cross_origin_isolated() {
                     // Create a non-shared ArrayBuffer for cross-origin isolated environments (Flutter).
                     let array_buffer: ArrayBuffer = ArrayBuffer::new(data.len() as u32);
                     let uint8_array = Uint8Array::new(&array_buffer);
                     uint8_array.copy_from(&data[..]);
-                    self.send_with_array_buffer(&array_buffer).map_err(|e| e.into())
+                    self.send_with_array_buffer(&array_buffer)
+                        .map_err(|e| e.into())
                 } else {
                     self.send_with_u8_array(data).map_err(|e| e.into())
                 }
-            },
+            }
             Message::Text(text) => self.send_with_str(text).map_err(|e| e.into()),
             _ => {
                 panic!("WebSocket trying to convert unsupported message type: `{message:?}`");


### PR DESCRIPTION
Android and IOs platform enabled (missed compatible if-branch) to prevent a crash on Android/IOs on init.

Runtime now detects a cross-origin isolated browser environment and websocket's send function creates a non-shared ArrayBuffer in that kind of environment to prevent following error:

"The provided ArrayBufferView value must not be shared."