### PR TITLE
Platform updates

### DIFF
--- a/core/src/wasm/overrides.rs
+++ b/core/src/wasm/overrides.rs
@@ -8,7 +8,7 @@ use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
 use web_sys::{window, Blob, BlobPropertyBag, Url, Worker};
 
-use crate::runtime::{is_cross_origin_isolated, is_web};
+use crate::runtime::{is_chrome_extension, is_cross_origin_isolated, is_web};
 
 pub struct TimerManager {
     worker: Worker,         // Used to run the JavaScript code in a separate thread
@@ -240,7 +240,8 @@ pub fn init_timer_overrides() -> Result<(), String> {
     }
 
     // Persistent timers shall only be injected in a web context.
-    if !is_web() || is_cross_origin_isolated() {
+    if !is_web() || is_cross_origin_isolated() || is_chrome_extension() {
+        DISABLED.store(true, Ordering::Relaxed);
         return Ok(());
     }
 


### PR DESCRIPTION
This PR replaces `static mut` declarations with `OnceLock` and fixes `is_chrome_extension()` check to use `is_web()` instead of `is_web_capable()`.

`Platform` as well as `is_chrome_extension()` are rewritten to use idiomatic Rust.